### PR TITLE
Bug fix

### DIFF
--- a/src/com/uwsoft/editor/controlles/ResolutionManager.java
+++ b/src/com/uwsoft/editor/controlles/ResolutionManager.java
@@ -412,8 +412,10 @@ public class ResolutionManager {
         TexturePacker.Settings settings = new TexturePacker.Settings();
 
         settings.flattenPaths = true;
-        settings.maxHeight = getMinSquareNum(resolution.height);
-        settings.maxWidth = getMinSquareNum(resolution.height);
+//        settings.maxHeight = getMinSquareNum(resolution.height);
+//        settings.maxWidth = getMinSquareNum(resolution.height);
+        settings.maxHeight = Integer.parseInt(dataManager.getCurrentProjectVO().texturepackerHeight);
+        settings.maxWidth = Integer.parseInt(dataManager.getCurrentProjectVO().texturepackerWidth);
         settings.filterMag = Texture.TextureFilter.Linear;
         settings.filterMin = Texture.TextureFilter.Linear;
 


### PR DESCRIPTION
Fixed bug were sprite animations for other resolutions different than  "orig", generated 4096x4096 texture packs. Now it generates images based in export settings.