### PR TITLE
+adds zoom, X and Y labels over sandbox

### DIFF
--- a/src/com/uwsoft/editor/gdx/sandbox/Sandbox.java
+++ b/src/com/uwsoft/editor/gdx/sandbox/Sandbox.java
@@ -516,6 +516,8 @@ public class Sandbox {
 		  zoomPercent = percent;
 		  OrthographicCamera camera = (OrthographicCamera)(sandboxStage.getCamera());
 		  camera.zoom = 1f/(zoomPercent/100f);
+		  
+		  uiStage.uiMainTable.updateZoom((int)(percent));
 	 }
 
 	 public void zoomBy(float amount) {

--- a/src/com/uwsoft/editor/gdx/stage/SandboxStage.java
+++ b/src/com/uwsoft/editor/gdx/stage/SandboxStage.java
@@ -18,11 +18,12 @@
 
 package com.uwsoft.editor.gdx.stage;
 
+import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.FPSLogger;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Group;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
-import com.uwsoft.editor.controlles.flow.FlowManager;
 import com.uwsoft.editor.data.TypeConstants;
 import com.uwsoft.editor.gdx.actors.basic.PixelRect;
 import com.uwsoft.editor.gdx.sandbox.Sandbox;
@@ -39,9 +40,11 @@ public class SandboxStage extends BaseStage implements TypeConstants {
     private FPSLogger fpsLogger;
 
 
-    public Group mainBox = new Group();
+    public Group mainBox;
 
     public Sandbox sandbox;
+    
+    private final static Vector2 temp = new Vector2();
 
     public SandboxStage() {
         super();
@@ -54,6 +57,15 @@ public class SandboxStage extends BaseStage implements TypeConstants {
     @Override
     public void act(float delta) {
         super.act(delta);
+        
+        // update X and Y labels if scene is initialized and not panning
+        if(!sandbox.cameraPanOn
+      	  && mainBox != null)
+        {
+      	  temp.set( Gdx.input.getX(), Gdx.input.getY() );
+      	  uiStage.uiMainTable.updateXandY(this.screenToStageCoordinates(temp));
+        }
+
     }
 
     public void setUIStage(UIStage uiStage) {
@@ -62,7 +74,7 @@ public class SandboxStage extends BaseStage implements TypeConstants {
 
 
     public void initView() {
-        if (mainBox != null) mainBox.clear();
+        mainBox  = new Group();
         clear();
         getCamera().position.set(0, 0, 0);
 
@@ -82,7 +94,6 @@ public class SandboxStage extends BaseStage implements TypeConstants {
         addActor(frontUI);
 
     }
-
 
     public void setKeyboardFocus() {
         setKeyboardFocus(mainBox);

--- a/src/com/uwsoft/editor/gdx/ui/UIMainTable.java
+++ b/src/com/uwsoft/editor/gdx/ui/UIMainTable.java
@@ -18,6 +18,7 @@
 
 package com.uwsoft.editor.gdx.ui;
 
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Touchable;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
@@ -43,6 +44,8 @@ public class UIMainTable extends Table {
 	public Table leftTable;
 	private UIToolBox toolPanel;
 	public Label lblZoom;
+	public Label lblX;
+	public Label lblY;
 	
 	private StringBuilder strBuilder;
 
@@ -116,6 +119,14 @@ public class UIMainTable extends Table {
 		//centerTable.debug();
 
 		// UI labels over sandbox
+		lblX = new Label("", DataManager.getInstance().textureManager.editorSkin);
+		lblX.setTouchable(Touchable.disabled);
+		centerTable.add(lblX).top().padRight(10);
+		
+		lblY = new Label("", DataManager.getInstance().textureManager.editorSkin);
+		lblY.setTouchable(Touchable.disabled);
+		centerTable.add(lblY).top().padRight(10);
+		
 		lblZoom = new Label("", DataManager.getInstance().textureManager.editorSkin);
 		lblZoom.setTouchable(Touchable.disabled);
 		centerTable.add(lblZoom).top().padRight(10);
@@ -154,6 +165,19 @@ public class UIMainTable extends Table {
 		strBuilder.append(String.valueOf(zoom));
 		strBuilder.append("%");
 		lblZoom.setText(strBuilder.toString());
+	}
+	
+	public void updateXandY(Vector2 coordinates)
+	{
+		strBuilder.setLength(0);
+		strBuilder.append("x: ");
+		strBuilder.append(String.valueOf((int) coordinates.x));
+		lblX.setText(strBuilder.toString());
+		
+		strBuilder.setLength(0);
+		strBuilder.append("y: ");
+		strBuilder.append(String.valueOf((int) coordinates.y));
+		lblY.setText(strBuilder.toString());
 	}
 
 }

--- a/src/com/uwsoft/editor/gdx/ui/UIMainTable.java
+++ b/src/com/uwsoft/editor/gdx/ui/UIMainTable.java
@@ -18,7 +18,10 @@
 
 package com.uwsoft.editor.gdx.ui;
 
+import com.badlogic.gdx.scenes.scene2d.Touchable;
+import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.uwsoft.editor.data.manager.DataManager;
 import com.uwsoft.editor.gdx.stage.UIStage;
 import com.uwsoft.editor.gdx.ui.layer.UILayerBox;
 import com.uwsoft.editor.gdx.ui.menubar.Overlap2DMenuBar;
@@ -28,95 +31,129 @@ import com.uwsoft.editor.gdx.ui.menubar.Overlap2DMenuBarMediator;
  * Created by sargis on 9/10/14.
  */
 public class UIMainTable extends Table {
-    private final UIStage uiStage;
-    public UICompositePanel compositePanel;
-    public UILayerBox layerPanel;
-    public UILightBox lightBox;
-    public UIItemsBox itemsBox;
-    public UIPropertiesBox propertiesPanel;
-    public UILibraryBox libraryPanel;
-    public Table rightTable;
-    public Table leftTable;
-    private UIToolBox toolPanel;
+	private final UIStage uiStage;
+	public UICompositePanel compositePanel;
+	public UILayerBox layerPanel;
+	public UILightBox lightBox;
+	public UIItemsBox itemsBox;
+	public UIPropertiesBox propertiesPanel;
+	public UILibraryBox libraryPanel;
+	public Table rightTable;
+	public Table centerTable;
+	public Table leftTable;
+	private UIToolBox toolPanel;
+	public Label lblZoom;
+	
+	private StringBuilder strBuilder;
 
-	 public Overlap2DMenuBarMediator menuMediator;
+	public Overlap2DMenuBarMediator menuMediator;
 
-    public UIMainTable(UIStage uiStage) {
-        this.uiStage = uiStage;
-        //debug(); // turn on all debug lines (uiMainTable, cell, and widget)
-        //debugTable(); // turn on only uiMainTable lines
-        //debugCell();
+	public UIMainTable(UIStage uiStage) {
+		this.uiStage = uiStage;
+		
+		strBuilder = new StringBuilder();
+		
+		//debug(); // turn on all debug lines (uiMainTable, cell, and widget)
+		//debugTable(); // turn on only uiMainTable lines
+		//debugCell();
 
-        top();
-        setFillParent(true);
-        //
-        initTop();
-        row();
-        initLeft();
-        initRight();
+		top();
+		setFillParent(true);
+		row().colspan(3);
+		//
+		initTop();
+		row();
+		//
+		initLeft(); // column 1
+		initCenter(); // column 2
+		initRight(); // column 3
 
-        //menu.setZIndex(9999);
-    }
+		//menu.setZIndex(9999);
+	}
+	
+	private void initTop() {
+		// init menu bar
+		menuMediator = new Overlap2DMenuBarMediator();
+		Overlap2DMenuBar menuBar = new Overlap2DMenuBar(menuMediator);
+		add(menuBar.getTable()).fillX().expandX();
+		
+		row().colspan(3);
+		
+		compositePanel = new UICompositePanel(uiStage);
+		compositePanel.initPanel();
+		add(compositePanel).left().expandX();
+	}
 
-    private void initRight() {
-        rightTable = new Table();
-//        rightTable.debug();
-//        rightTable.debugTable();
-//        rightTable.debugCell();
-        rightTable.padTop(10);
-        //
-        propertiesPanel = new UIPropertiesBox(uiStage);
-        propertiesPanel.initPanel();
-        rightTable.add(propertiesPanel).top().fillY();
-        rightTable.row();
-        //
-        libraryPanel = new UILibraryBox(uiStage);
-        libraryPanel.initPanel();
-        rightTable.add(libraryPanel).top().fillY();
-        rightTable.row();
-        //
-        layerPanel = new UILayerBox(uiStage);
-        layerPanel.initPanel();
-        rightTable.add(layerPanel).top().fillY();
-        //
-        add(rightTable).top().right().padRight(5).expand();
-    }
-
-    private void initLeft() {
-        //
-        leftTable = new Table();
-//        leftTable.debug();
+	private void initLeft() {
+		//
+		leftTable = new Table();
+		//leftTable.debug();
 //        leftTable.debugTable();
 //        leftTable.debugCell();
-        leftTable.padTop(10);
-        //
-        toolPanel = new UIToolBox(uiStage);
-        toolPanel.initPanel();
-        leftTable.add(toolPanel).top().fillY();
-        leftTable.row();
-        //
-        lightBox = new UILightBox(uiStage);
-        lightBox.initPanel();
-        leftTable.add(lightBox).top().fillY();
-        leftTable.row();
-        //
-        itemsBox = new UIItemsBox(uiStage);
-        itemsBox.initPanel();
-        leftTable.add(itemsBox).top().fillY();
-        //
-        add(leftTable).top().left().padLeft(5).expand();
-    }
+		leftTable.padTop(10);
+		//
+		toolPanel = new UIToolBox(uiStage);
+		toolPanel.initPanel();
+		leftTable.add(toolPanel).top().fillY();
+		leftTable.row();
+		//
+		lightBox = new UILightBox(uiStage);
+		lightBox.initPanel();
+		leftTable.add(lightBox).top().fillY();
+		leftTable.row();
+		//
+		itemsBox = new UIItemsBox(uiStage);
+		itemsBox.initPanel();
+		leftTable.add(itemsBox).top().fillY();
+		//
+		add(leftTable).top().left().padLeft(5);
+	}
 
-    private void initTop() {
-        // init menu bar
-		  menuMediator = new Overlap2DMenuBarMediator();
-		  Overlap2DMenuBar menuBar = new Overlap2DMenuBar(menuMediator);
+	private void initCenter() {
+		centerTable = new Table();
+		centerTable.padTop(10);
 
-        add(menuBar.getTable()).fillX().expandX().row();
-        //
-        compositePanel = new UICompositePanel(uiStage);
-        compositePanel.initPanel();
-        add(compositePanel).left().expandX();
-        add();
-    }
+		//centerTable.debug();
+
+		// UI labels over sandbox
+		lblZoom = new Label("", DataManager.getInstance().textureManager.editorSkin);
+		lblZoom.setTouchable(Touchable.disabled);
+		centerTable.add(lblZoom).top().padRight(10);
+		
+		add(centerTable).top().expand().right();
+	}
+	
+	private void initRight() {
+		rightTable = new Table();
+//		rightTable.debug();
+//        rightTable.debugTable();
+//        rightTable.debugCell();
+		rightTable.padTop(10);
+		//
+		propertiesPanel = new UIPropertiesBox(uiStage);
+		propertiesPanel.initPanel();
+		rightTable.add(propertiesPanel).top().fillY();
+		rightTable.row();
+		//
+		libraryPanel = new UILibraryBox(uiStage);
+		libraryPanel.initPanel();
+		rightTable.add(libraryPanel).top().fillY();
+		rightTable.row();
+		//
+		layerPanel = new UILayerBox(uiStage);
+		layerPanel.initPanel();
+		rightTable.add(layerPanel).top().fillY();
+		//
+		add(rightTable).top().right().padRight(5);
+	}
+	
+	public void updateZoom(int zoom)
+	{
+		strBuilder.setLength(0);
+		strBuilder.append("Zoom: ");
+		strBuilder.append(String.valueOf(zoom));
+		strBuilder.append("%");
+		lblZoom.setText(strBuilder.toString());
+	}
+
 }


### PR DESCRIPTION
As a way to introduce me to the code, I decide to add a simple zoom indicator text over the Sandbox UI, keeping the same structure than before.
This zoom indicator will only appear if there is a project opened and makes things clearer to the user.

It looks as follows:

![pull_request](https://cloud.githubusercontent.com/assets/4955150/7544684/8e3bf454-f5cf-11e4-9c26-64c0373d8b38.PNG)
