### PR TITLE
Tiny fix on physic property combo 

### DIFF
--- a/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsProperties.java
+++ b/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsProperties.java
@@ -133,7 +133,7 @@ public class UIPhysicsProperties extends UIRemovableProperties {
 
     public int getBodyType() {
         for(Integer key: bodyTypes.keySet()) {
-            if(key.equals(bodyTypeBox.getSelected())) {
+            if(bodyTypes.get(key).equals(bodyTypeBox.getSelected())) {
                 return key;
             }
         }


### PR DESCRIPTION
On PhysicProperties panel Body type change ignored due to bad combo value selection  