### PR TITLE
Suppressing menu bar separator when not needed

### DIFF
--- a/src/com/uwsoft/editor/view/Overlap2DMenuBar.java
+++ b/src/com/uwsoft/editor/view/Overlap2DMenuBar.java
@@ -248,7 +248,9 @@ public class Overlap2DMenuBar extends CustomMenuBar {
 
             addRecent(paths);
 
-            recentProjectsPopupMenu.addSeparator();
+            if (paths.size() > 0) {
+            	recentProjectsPopupMenu.addSeparator();
+            }
 
             MenuItem menuItem = new MenuItem("Clear list", new MenuItemListener(CLEAR_RECENTS, null, FILE_MENU));
             recentProjectsMenuItems.add(menuItem);


### PR DESCRIPTION
The "Recent Projects..." submenu don't need separator from "Clear list" option when it is empty.
![separator](https://cloud.githubusercontent.com/assets/1621979/8854776/f4b7814e-3161-11e5-9ed8-3c971c212c43.png)

I know this is no real issue :smile:. I'm just learning how to do a push request in GIT. 