### PR TITLE
#129 +adds rename layer feature (pending to add validator and filter)

### DIFF
--- a/assets/style/uiskin.json
+++ b/assets/style/uiskin.json
@@ -307,6 +307,13 @@
       "fontColor": "white",
       "disabledFontColor": "grey",
       "cursor": "cursor"
+    },
+    "transparent": {
+      "selection": "selection",
+      "focusBorder": "border",
+      "errorBorder": "border-error",
+      "font": "default-font",
+      "fontColor": "white"
     }
   },
   "com.kotcrab.vis.ui.widget.VisImageTextButton$VisImageTextButtonStyle": {

--- a/assets/style/uiskin.json
+++ b/assets/style/uiskin.json
@@ -309,11 +309,12 @@
       "cursor": "cursor"
     },
     "transparent": {
-      "selection": "selection",
+      "selection": "default-select-selection",
       "focusBorder": "border",
       "errorBorder": "border-error",
       "font": "default-font",
-      "fontColor": "white"
+      "fontColor": "white",
+      "cursor": "cursor"
     }
   },
   "com.kotcrab.vis.ui.widget.VisImageTextButton$VisImageTextButtonStyle": {

--- a/src/com/uwsoft/editor/event/KeyboardListener.java
+++ b/src/com/uwsoft/editor/event/KeyboardListener.java
@@ -86,10 +86,10 @@ public class KeyboardListener implements EventListener {
             return;
         }
         // check for change
-        if(lastValue.equals(target.getText())) {
+        /*if(lastValue.equals(target.getText())) {
             // no change = no event;
             return;
-        }
+        }*/
 
         Overlap2DFacade facade = Overlap2DFacade.getInstance();
         facade.sendNotification(eventName, target.getText());

--- a/src/com/uwsoft/editor/utils/InputFilters.java
+++ b/src/com/uwsoft/editor/utils/InputFilters.java
@@ -1,0 +1,16 @@
+package com.uwsoft.editor.utils;
+
+import com.kotcrab.vis.ui.widget.VisTextField;
+
+public class InputFilters {
+	public static final VisTextField.TextFieldFilter ALPHANUMERIC = new VisTextField.TextFieldFilter() {
+		@Override
+		public boolean acceptChar(VisTextField textField, char c) {
+
+			if(Character.isAlphabetic(c) || Character.isDigit(c))
+				return true;
+
+			return false;
+		}
+	};
+}

--- a/src/com/uwsoft/editor/utils/StandardWidgetsFactory.java
+++ b/src/com/uwsoft/editor/utils/StandardWidgetsFactory.java
@@ -67,19 +67,29 @@ public class StandardWidgetsFactory {
     public static  VisTextField createTextField() {
         return createTextField("default");
     }
-
+    
     public static  VisTextField createTextField(String style) {
-        VisTextField visTextField = new VisTextField("", style);
-        visTextField.addListener(new CursorListener(CursorManager.TEXT));
-        return visTextField;
+    	VisTextField visTextField = new VisTextField("", style);
+    	visTextField.addListener(new CursorListener(CursorManager.TEXT));
+    	return visTextField;
     }
 
+    public static  VisTextField createTextField(String style, boolean textCursor)
+    {
+    	VisTextField visTextField = new VisTextField();
+        Skin skin = VisUI.getSkin();
+        visTextField.setStyle(skin.get(style, VisTextField.VisTextFieldStyle.class));
+        if(textCursor)
+        	visTextField.addListener(new CursorListener(CursorManager.TEXT));
+        return visTextField;
+    }
+    
     public static  VisTextField createTextField(String style, VisTextField.TextFieldFilter textFieldFilter) {
         VisTextField visTextField = createTextField(style);
         visTextField.setTextFieldFilter(textFieldFilter);
         return visTextField;
     }
-
+    
     public static  VisValidableTextField createValidableTextField(InputValidator inputValidator) {
         VisValidableTextField visTextField = createValidableTextField("default", inputValidator);
         return visTextField;

--- a/src/com/uwsoft/editor/view/ui/box/UILayerBox.java
+++ b/src/com/uwsoft/editor/view/ui/box/UILayerBox.java
@@ -21,7 +21,6 @@ package com.uwsoft.editor.view.ui.box;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.Cell;
-import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
@@ -32,10 +31,10 @@ import com.kotcrab.vis.ui.widget.VisImageButton;
 import com.kotcrab.vis.ui.widget.VisScrollPane;
 import com.kotcrab.vis.ui.widget.VisTable;
 import com.kotcrab.vis.ui.widget.VisTextField;
-import com.kotcrab.vis.ui.widget.VisTextField.TextFieldListener;
-import com.kotcrab.vis.ui.widget.VisTextField.VisTextFieldStyle;
 import com.uwsoft.editor.Overlap2DFacade;
+import com.uwsoft.editor.event.KeyboardListener;
 import com.uwsoft.editor.renderer.data.LayerItemVO;
+import com.uwsoft.editor.utils.InputFilters;
 import com.uwsoft.editor.utils.StandardWidgetsFactory;
 
 /**
@@ -44,8 +43,9 @@ import com.uwsoft.editor.utils.StandardWidgetsFactory;
 public class UILayerBox extends UICollapsibleBox {
 
     public static final String LAYER_ROW_CLICKED = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".LAYER_ROW_CLICKED";
-    public static final String CREATE_NEW_LAYER = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".CREATE_NEW_LAYER";
-    public static final String DELETE_NEW_LAYER = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".DELETE_NEW_LAYER";
+    public static final String CREATE_NEW_LAYER =  "com.uwsoft.editor.view.ui.box.UILayerBox" + ".CREATE_NEW_LAYER";
+    public static final String DELETE_NEW_LAYER =  "com.uwsoft.editor.view.ui.box.UILayerBox" + ".DELETE_NEW_LAYER";
+    public static final String CHANGE_LAYER_NAME = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".CHANGE_LAYER_NAME";
     public static final String LOCK_LAYER = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".LOCK_LAYER";
     public static final String HIDE_LAYER = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".HIDE_LAYER";
     public static final String LAYER_DROPPED = "com.uwsoft.editor.view.ui.box.UILayerBox" + ".LAYER_DROPPED";
@@ -57,6 +57,8 @@ public class UILayerBox extends UICollapsibleBox {
     private VisTable bottomPane;
     private VisScrollPane scrollPane;
     private VisTable layersTable;
+    
+    private SlotSource sourceInEdition;
 
     private Array<UILayerItemSlot> rows = new Array<>();
 
@@ -103,15 +105,31 @@ public class UILayerBox extends UICollapsibleBox {
         });
         dragAndDrop = new DragAndDrop();
 
-
-
         createCollapsibleWidget(contentTable);
     }
 
+    public void enableDraggingInEditedSlot() {
+    	if(sourceInEdition != null)
+    	{
+    		dragAndDrop.addSource(sourceInEdition);
+    		sourceInEdition = null;
+    	}
+    }
+    public void disableDraggingInEditedSlot() {
+    	if(sourceInEdition != null)
+    	{
+    		dragAndDrop.removeSource(sourceInEdition);
+    	}
+    }
+    
     public int getCurrentSelectedLayerIndex() {
         return currentSelectedLayerIndex;
     }
 
+    public UILayerItem getCurrentSelectedLayer() {
+    	return rows.get(rows.size-1-currentSelectedLayerIndex).uiLayerItem;
+    }
+    
     public void clearItems() {
         layersTable.clear();
         rows.clear();
@@ -129,13 +147,14 @@ public class UILayerBox extends UICollapsibleBox {
         clearSelection();
         slot.getUiLayerItem().setSelected(true);
     }
-
+    
     public void addItem(LayerItemVO itemVO) {
         UILayerItemSlot itemSlot = new UILayerItemSlot();
         UILayerItem item = new UILayerItem(itemVO, itemSlot);
         layersTable.add(itemSlot).left().expandX().fillX();
         layersTable.row().padTop(1);
-        dragAndDrop.addSource(new SlotSource(item));
+        SlotSource sourceItem = new SlotSource(item);
+        dragAndDrop.addSource(sourceItem);
         dragAndDrop.addTarget(new SlotTarget(itemSlot));
         dragAndDrop.setDragActorPosition(0, 0);
         rows.add(itemSlot);
@@ -144,6 +163,20 @@ public class UILayerBox extends UICollapsibleBox {
             @Override
             public void clicked(InputEvent event, float x, float y) {
                 super.clicked(event, x, y);
+                
+        		VisTextField textField = itemSlot.getUiLayerItem().getNameField();
+
+                if(sourceInEdition != null)
+                {
+                	VisTextField prevField = ((UILayerItem) sourceInEdition.getActor()).getNameField();
+                	if(textField != prevField)
+                	{
+                		prevField.clearSelection();
+                		prevField.setDisabled(true);
+                		enableDraggingInEditedSlot();
+                	}
+                }
+                
                 clearSelection();
                 itemSlot.getUiLayerItem().setSelected(true);
                 currentSelectedLayerIndex = rows.size - rows.indexOf(itemSlot, true) - 1;
@@ -153,10 +186,11 @@ public class UILayerBox extends UICollapsibleBox {
                 // Change name mode if double click
             	if(getTapCount() == 2)
             	{
-            		VisTextField textField = itemSlot.getUiLayerItem().getNameField();
+            		sourceInEdition = sourceItem;
             		textField.setDisabled(false);
             		textField.focusField();
             		textField.selectAll();
+            		disableDraggingInEditedSlot();
             	}
             }
         });
@@ -282,7 +316,6 @@ public class UILayerBox extends UICollapsibleBox {
 
     public class UILayerItem extends VisTable {
 
-
         private final LayerItemVO layerData;
         private UILayerItemSlot itemSlot;
         private boolean selected;
@@ -299,18 +332,14 @@ public class UILayerBox extends UICollapsibleBox {
             visibleBtn.addListener(new VisibleClickListener());
             add(lockBtn).left();
             add(visibleBtn).left().padRight(6);
-            // TODO: InputValidator and Filter
-            //VisTextField layerName = StandardWidgetsFactory.createValidableTextField("transparent"/*, null, null*/);
-            layerNameField = StandardWidgetsFactory.createTextField("transparent");
+            
+            layerNameField = StandardWidgetsFactory.createTextField("transparent", false);
+            layerNameField.setTextFieldFilter(InputFilters.ALPHANUMERIC);
             layerNameField.setText(layerData.layerName);
             layerNameField.setDisabled(true);
-            // Listener to update layer name
-            layerNameField.setTextFieldListener( new TextFieldListener() {
-				@Override
-				public void keyTyped(VisTextField textField, char c) {
-					layerData.layerName = textField.getText();
-				}
-            });
+            // This listener will manage Enter and lost focus events
+            layerNameField.addListener(new KeyboardListener(CHANGE_LAYER_NAME));
+            
             add(layerNameField).expandX().fillX();
             itemSlot.setLayerItem(this);
         }

--- a/src/com/uwsoft/editor/view/ui/box/UILayerBox.java
+++ b/src/com/uwsoft/editor/view/ui/box/UILayerBox.java
@@ -21,6 +21,7 @@ package com.uwsoft.editor.view.ui.box;
 import com.badlogic.gdx.scenes.scene2d.Actor;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.Cell;
+import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.utils.ChangeListener;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.DragAndDrop;
@@ -30,9 +31,12 @@ import com.kotcrab.vis.ui.VisUI;
 import com.kotcrab.vis.ui.widget.VisImageButton;
 import com.kotcrab.vis.ui.widget.VisScrollPane;
 import com.kotcrab.vis.ui.widget.VisTable;
+import com.kotcrab.vis.ui.widget.VisTextField;
+import com.kotcrab.vis.ui.widget.VisTextField.TextFieldListener;
+import com.kotcrab.vis.ui.widget.VisTextField.VisTextFieldStyle;
 import com.uwsoft.editor.Overlap2DFacade;
-import com.uwsoft.editor.renderer.components.LayerMapComponent;
 import com.uwsoft.editor.renderer.data.LayerItemVO;
+import com.uwsoft.editor.utils.StandardWidgetsFactory;
 
 /**
  * Created by azakhary on 4/17/2015.
@@ -145,8 +149,18 @@ public class UILayerBox extends UICollapsibleBox {
                 currentSelectedLayerIndex = rows.size - rows.indexOf(itemSlot, true) - 1;
 
                 facade.sendNotification(LAYER_ROW_CLICKED, itemSlot.getUiLayerItem());
+                
+                // Change name mode if double click
+            	if(getTapCount() == 2)
+            	{
+            		VisTextField textField = itemSlot.getUiLayerItem().getNameField();
+            		textField.setDisabled(false);
+            		textField.focusField();
+            		textField.selectAll();
+            	}
             }
         });
+
     }
 
     private static class SlotSource extends DragAndDrop.Source {
@@ -272,6 +286,8 @@ public class UILayerBox extends UICollapsibleBox {
         private final LayerItemVO layerData;
         private UILayerItemSlot itemSlot;
         private boolean selected;
+        
+        private VisTextField layerNameField;
 
         public UILayerItem(LayerItemVO layerData, UILayerItemSlot itemSlot) {
             super();
@@ -283,11 +299,26 @@ public class UILayerBox extends UICollapsibleBox {
             visibleBtn.addListener(new VisibleClickListener());
             add(lockBtn).left();
             add(visibleBtn).left().padRight(6);
-            add(layerData.layerName).expandX().fillX();
-            //
+            // TODO: InputValidator and Filter
+            //VisTextField layerName = StandardWidgetsFactory.createValidableTextField("transparent"/*, null, null*/);
+            layerNameField = StandardWidgetsFactory.createTextField("transparent");
+            layerNameField.setText(layerData.layerName);
+            layerNameField.setDisabled(true);
+            // Listener to update layer name
+            layerNameField.setTextFieldListener( new TextFieldListener() {
+				@Override
+				public void keyTyped(VisTextField textField, char c) {
+					layerData.layerName = textField.getText();
+				}
+            });
+            add(layerNameField).expandX().fillX();
             itemSlot.setLayerItem(this);
         }
 
+        public VisTextField getNameField() {
+        	return layerNameField;
+        }
+        
         public boolean isLocked() {
             return layerData.isLocked;
         }

--- a/src/com/uwsoft/editor/view/ui/box/UILayerBoxMediator.java
+++ b/src/com/uwsoft/editor/view/ui/box/UILayerBoxMediator.java
@@ -27,6 +27,7 @@ import com.badlogic.ashley.core.Entity;
 import com.badlogic.gdx.utils.Array;
 import com.kotcrab.vis.ui.util.dialog.DialogUtils;
 import com.kotcrab.vis.ui.util.dialog.InputDialogListener;
+import com.kotcrab.vis.ui.widget.VisTextField;
 import com.puremvc.patterns.observer.Notification;
 import com.uwsoft.editor.Overlap2D;
 import com.uwsoft.editor.Overlap2DFacade;
@@ -64,6 +65,7 @@ public class UILayerBoxMediator extends PanelMediator<UILayerBox> {
                 SceneDataManager.SCENE_LOADED,
                 UILayerBox.LAYER_ROW_CLICKED,
                 UILayerBox.CREATE_NEW_LAYER,
+                UILayerBox.CHANGE_LAYER_NAME,
                 UILayerBox.DELETE_NEW_LAYER,
                 UILayerBox.LOCK_LAYER,
                 UILayerBox.HIDE_LAYER,
@@ -146,6 +148,32 @@ public class UILayerBoxMediator extends PanelMediator<UILayerBox> {
                 MainItemComponent mainItemComponent = ComponentRetriever.get(item, MainItemComponent.class);
                 mainItemComponent.layer = layers.get(index).layerName;
                 break;
+            case UILayerBox.CHANGE_LAYER_NAME:
+            	String layerName = notification.getBody();
+            	int layerIndex = viewComponent.getCurrentSelectedLayerIndex();
+            	LayerItemVO layer_view = layers.get(layerIndex);
+            	layerItem = viewComponent.getCurrentSelectedLayer();
+            	VisTextField textField = layerItem.getNameField();
+            	
+            	if(layer_view.layerName.equals(layerName))  // Name didn't change
+            	{
+	            	textField.clearSelection();
+            		textField.setDisabled(true);
+            		viewComponent.enableDraggingInEditedSlot();
+            	}
+            	else if(checkIfNameIsUnique(layerName)) // Name changed
+            	{
+	            	textField.clearSelection();
+            		textField.setDisabled(true);
+            		viewComponent.enableDraggingInEditedSlot();
+
+	            	layer_view.layerName = layerName;
+            	}
+            	else
+            	{
+            		//Show error dialog
+            	}
+            	break;
             default:
                 break;
         }


### PR DESCRIPTION
Fixes #129 

Adds rename layer feature with double click on the layer slot.

Code format/enconding doesn't seem to be the same so the whole file has been changed.
To make your life easier, I have just changed:
- UILayerBox -> UILayerItem
   * I have added the layer name as a TextField instead of a simple Label.
- uiSkin.json
   * I have added "transparent" style for TextFields