### PR TITLE
quick fix for: newly created composite is assigned to "Default" layer

### DIFF
--- a/src/com/uwsoft/editor/controller/commands/ConvertToCompositeCommand.java
+++ b/src/com/uwsoft/editor/controller/commands/ConvertToCompositeCommand.java
@@ -32,6 +32,7 @@ import com.uwsoft.editor.renderer.components.DimensionsComponent;
 import com.uwsoft.editor.renderer.components.TransformComponent;
 import com.uwsoft.editor.renderer.utils.ComponentRetriever;
 import com.uwsoft.editor.utils.runtime.EntityUtils;
+import com.uwsoft.editor.view.ui.box.UILayerBoxMediator;
 
 /**
  * Created by azakhary on 4/28/2015.
@@ -50,6 +51,7 @@ public class ConvertToCompositeCommand extends EntityModifyRevertableCommand {
     public void doAction() {
         // get entity list
         HashSet<Entity> entities = (HashSet<Entity>) sandbox.getSelector().getSelectedItems();
+        UILayerBoxMediator layerBoxMediator = facade.retrieveMediator(UILayerBoxMediator.NAME);
 
         if(layersBackup == null) {
             // backup layer data
@@ -78,8 +80,8 @@ public class ConvertToCompositeCommand extends EntityModifyRevertableCommand {
         //reposition children
         for(Entity tmpEntity: entities) {
             TransformComponent transformComponent = ComponentRetriever.get(tmpEntity, TransformComponent.class);
-            transformComponent.x-=position.x;
-            transformComponent.y-=position.y;
+            transformComponent.x -= position.x;
+            transformComponent.y -=position.y;
 
             // put it on default layer
             ZIndexComponent zIndexComponent = ComponentRetriever.get(entity, ZIndexComponent.class);
@@ -91,6 +93,9 @@ public class ConvertToCompositeCommand extends EntityModifyRevertableCommand {
         Vector2 newSize = EntityUtils.getRightTopPoint(entities);
         dimensionsComponent.width = newSize.x;
         dimensionsComponent.height = newSize.y;
+
+        ZIndexComponent zIndexComponent = ComponentRetriever.get(entity, ZIndexComponent.class);
+        zIndexComponent.layerName = layerBoxMediator.getCurrentSelectedLayerName();
 
         //let everyone know
         Overlap2DFacade.getInstance().sendNotification(DONE);


### PR DESCRIPTION
fixes #209
actually I'm not sure, if either `sandbox.getSelector()` or `facade.retrieveMediator` should be called in a Command class or sent by notification?