### PR TITLE
Use same default path for open project and create project

### DIFF
--- a/src/com/uwsoft/editor/view/menu/Overlap2DMenuBarMediator.java
+++ b/src/com/uwsoft/editor/view/menu/Overlap2DMenuBarMediator.java
@@ -225,6 +225,7 @@ public class Overlap2DMenuBarMediator extends SimpleMediator<Overlap2DMenuBar> {
         //fileChooser.setFileFilter(new SuffixFileFilter(".pit"));
 
         fileChooser.setMultiselectionEnabled(false);
+        fileChooser.setDirectory(projectManager.getWorkspacePath());
         fileChooser.setListener(new FileChooserAdapter() {
             @Override
             public void selected(FileHandle file) {


### PR DESCRIPTION
The default path for creating new project and opening project is different. It will be more convenience if we keep them same.

By the way, I notice that for now, we don't have any unit test in project. I'm thinking can we add some unit test and add travis support? If we have unit test and travis ci, it will make us more confident to add new code and merge pull request.

If everyone is OK with this idea, I can contribute some test code. Of course, I know some code are related to UI system which maybe a little hard to add unit test, but we can start from some small class.