### PR TITLE
Tool tips for tool box

### DIFF
--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/ConeLightTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/ConeLightTool.java
@@ -30,6 +30,7 @@ import com.uwsoft.editor.renderer.factory.EntityFactory;
 public class ConeLightTool extends ItemDropTool {
 
     public static final String NAME = "CONE_LIGHT_TOOL";
+    public static final String TOOL_TIP = "CONE_LIGHT_TOOL TOOL TIP";
 
 
     @Override

--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/PointLightTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/PointLightTool.java
@@ -30,6 +30,7 @@ import com.uwsoft.editor.renderer.factory.EntityFactory;
 public class PointLightTool extends ItemDropTool {
 
     public static final String NAME = "POINT_LIGHT_TOOL";
+    public static final String TOOL_TIP = "POINT_LIGHT_TOOL TOOL TIP";
 
 
     @Override

--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/PolygonTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/PolygonTool.java
@@ -50,6 +50,7 @@ import java.util.Set;
 public class PolygonTool extends SelectionTool implements PolygonTransformationListener {
 
     public static final String NAME = "MESH_TOOL";
+    public static final String TOOL_TIP = "MESH_TOOL TOOL TIP";
 
     private FollowersUIMediator followersUIMediator;
 

--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/SelectionTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/SelectionTool.java
@@ -46,6 +46,7 @@ import com.uwsoft.editor.renderer.utils.ComponentRetriever;
 public class SelectionTool extends SimpleTool {
 
     public static final String NAME = "SELECTION_TOOL";
+    public static final String TOOL_TIP = "SELECTION_TOOL TOOL TIP";
 
     protected Sandbox sandbox;
 

--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/TextTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/TextTool.java
@@ -33,6 +33,7 @@ import com.uwsoft.editor.renderer.factory.EntityFactory;
 public class TextTool extends ItemDropTool {
 
     public static final String NAME = "TEXT_TOOL";
+    public static final String TOOL_TIP = "TEXT_TOOL TOOL TIP";
 
     private String fontFamily;
     private boolean isBold;

--- a/overlap2d/src/com/uwsoft/editor/view/stage/tools/TransformTool.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/tools/TransformTool.java
@@ -49,6 +49,7 @@ import com.uwsoft.editor.utils.runtime.EntityUtils;
 public class TransformTool extends SelectionTool implements FollowerTransformationListener {
 
     public static final String NAME = "TRANSFORM_TOOL";
+    public static final String TOOL_TIP = "TRANSFORM_TOOL TOOL TIP";
 
     private float lastTransformAngle = 0;
     private float lastEntityAngle = 0;

--- a/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBox.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBox.java
@@ -20,11 +20,14 @@ package com.uwsoft.editor.view.ui.box;
 
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.utils.Array;
+import com.kotcrab.vis.ui.widget.Tooltip;
 import com.kotcrab.vis.ui.widget.VisImageButton;
 import com.kotcrab.vis.ui.widget.VisTable;
 import com.uwsoft.editor.Overlap2DFacade;
@@ -42,22 +45,26 @@ public class UIToolBox extends VisTable {
         toolsButtonGroup = new ButtonGroup<>();
     }
 
-    public void createToolButtons(Array<String> toolList) {
-        for(int i = 0; i < toolList.size; i++) {
-            addToolButton(toolList.get(i));
-            row();
-            if(i == 1) addSeparator().width(31);
-        }
+    public void createToolButtons(Map<String, String> toolList) {
+    	int index = 0;
+    	for (Entry<String, String> entry : toolList.entrySet()) {
+    		addToolButton(entry.getKey(), entry.getValue());
+    		row();
+    		if(index == 1)
+    			addSeparator().width(31f);
+    		index++;
+    	}
     }
 
-    private void addToolButton(String name) {
-        VisImageButton button = createButton("tool-" + name, name);
+    private void addToolButton(String name, String toolTip) {
+        VisImageButton button = createButton("tool-" + name, name, toolTip);
         buttonMap.put(name, button);
         add(button).width(31).height(31);
     }
 
-    private VisImageButton createButton(String styleName, String toolId) {
+    private VisImageButton createButton(String styleName, String toolId, String toolTip) {
         VisImageButton visImageButton = new VisImageButton(styleName);
+        new Tooltip(visImageButton, toolTip);
         toolsButtonGroup.add(visImageButton);
         visImageButton.addListener(new ToolboxButtonClickListener(toolId));
         return visImageButton;

--- a/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBox.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBox.java
@@ -26,7 +26,6 @@ import java.util.Map.Entry;
 import com.badlogic.gdx.scenes.scene2d.InputEvent;
 import com.badlogic.gdx.scenes.scene2d.ui.ButtonGroup;
 import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
-import com.badlogic.gdx.utils.Array;
 import com.kotcrab.vis.ui.widget.Tooltip;
 import com.kotcrab.vis.ui.widget.VisImageButton;
 import com.kotcrab.vis.ui.widget.VisTable;

--- a/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBoxMediator.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBoxMediator.java
@@ -20,7 +20,6 @@ package com.uwsoft.editor.view.ui.box;
 
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -63,13 +62,6 @@ public class UIToolBoxMediator extends SimpleMediator<UIToolBox> {
 
 
     public Map<String, String> getToolNameList() {
-//        Array<String> toolNames = new Array();
-//        toolNames.add(SelectionTool.NAME);
-//        toolNames.add(TransformTool.NAME);
-//        toolNames.add(TextTool.NAME);
-//        toolNames.add(PointLightTool.NAME);
-//        toolNames.add(ConeLightTool.NAME);
-//        toolNames.add(PolygonTool.NAME);
     	 return Collections.unmodifiableMap(new LinkedHashMap<String, String>() {
              {
                  put(SelectionTool.NAME, SelectionTool.TOOL_TIP);

--- a/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBoxMediator.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/box/UIToolBoxMediator.java
@@ -18,11 +18,21 @@
 
 package com.uwsoft.editor.view.ui.box;
 
-import com.badlogic.gdx.utils.Array;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import com.puremvc.patterns.mediator.SimpleMediator;
 import com.puremvc.patterns.observer.Notification;
 import com.uwsoft.editor.Overlap2DFacade;
-import com.uwsoft.editor.view.stage.tools.*;
+import com.uwsoft.editor.view.stage.tools.ConeLightTool;
+import com.uwsoft.editor.view.stage.tools.PointLightTool;
+import com.uwsoft.editor.view.stage.tools.PolygonTool;
+import com.uwsoft.editor.view.stage.tools.SelectionTool;
+import com.uwsoft.editor.view.stage.tools.TextTool;
+import com.uwsoft.editor.view.stage.tools.TransformTool;
 
 /**
  * Created by sargis on 4/9/15.
@@ -34,10 +44,8 @@ public class UIToolBoxMediator extends SimpleMediator<UIToolBox> {
     private static final String PREFIX =  "com.uwsoft.editor.view.ui.box.UIToolBoxMediator.";
     public static final String TOOL_SELECTED = PREFIX + ".TOOL_CHANGED";
 
-
     private String currentTool;
-    private Array<String> toolList;
-
+    private Map<String, String> toolList;
 
     public UIToolBoxMediator() {
         super(NAME, new UIToolBox());
@@ -54,15 +62,24 @@ public class UIToolBoxMediator extends SimpleMediator<UIToolBox> {
     }
 
 
-    public Array<String> getToolNameList() {
-        Array<String> toolNames = new Array();
-        toolNames.add(SelectionTool.NAME);
-        toolNames.add(TransformTool.NAME);
-        toolNames.add(TextTool.NAME);
-        toolNames.add(PointLightTool.NAME);
-        toolNames.add(ConeLightTool.NAME);
-        toolNames.add(PolygonTool.NAME);
-        return toolNames;
+    public Map<String, String> getToolNameList() {
+//        Array<String> toolNames = new Array();
+//        toolNames.add(SelectionTool.NAME);
+//        toolNames.add(TransformTool.NAME);
+//        toolNames.add(TextTool.NAME);
+//        toolNames.add(PointLightTool.NAME);
+//        toolNames.add(ConeLightTool.NAME);
+//        toolNames.add(PolygonTool.NAME);
+    	 return Collections.unmodifiableMap(new LinkedHashMap<String, String>() {
+             {
+                 put(SelectionTool.NAME, SelectionTool.TOOL_TIP);
+                 put(TransformTool.NAME, TransformTool.TOOL_TIP);
+                 put(TextTool.NAME, TextTool.TOOL_TIP);
+                 put(PointLightTool.NAME, PointLightTool.TOOL_TIP);
+                 put(ConeLightTool.NAME, ConeLightTool.TOOL_TIP);
+                 put(PolygonTool.NAME, PolygonTool.TOOL_TIP);
+             }
+         });
     }
 
     @Override


### PR DESCRIPTION
Added tool tips in tool box UI part. Not the cleanest solution,  but i didn't want to refactor to much code for simple improvement. 

And i could use some help with setting back ground in tool tip. I modified uiskin.json and uiskin.atlas (didin't commint them), to read the tooltip-bg, but still it is mess. 
![badbg](https://cloud.githubusercontent.com/assets/3685914/9887037/31f9d3a4-5bf6-11e5-9443-c2283719d45c.png)
