### PR TITLE
Remove odd null checks

### DIFF
--- a/overlap2d/src/com/uwsoft/editor/event/MenuItemListener.java
+++ b/overlap2d/src/com/uwsoft/editor/event/MenuItemListener.java
@@ -34,15 +34,6 @@ public class MenuItemListener extends ChangeListener {
 
     @Override
     public void changed(ChangeEvent event, Actor actor) {
-        if(menuType == null) {
-            if(data == null) {
-                facade.sendNotification(menuCommand);
-            } else {
-                facade.sendNotification(menuCommand, data);
-            }
-        } else {
             facade.sendNotification(menuCommand, data, menuType);
-        }
-
     }
 }


### PR DESCRIPTION
Since sendNotification(menuCommand) and sendNotification(menuCommand, data) both call sendNotification(menuCommand, data, menuType), null checks are completely pointless.