### PR TITLE
Fix bug with opening project

### DIFF
--- a/overlap2d/src/com/uwsoft/editor/proxy/ProjectManager.java
+++ b/overlap2d/src/com/uwsoft/editor/proxy/ProjectManager.java
@@ -1087,7 +1087,7 @@ public class ProjectManager extends BaseProxy {
     }
 
     public FileHandle getWorkspacePath() {
-        if(editorConfigVO.lastOpenedSystemPath != null) {
+        if (!editorConfigVO.lastOpenedSystemPath.isEmpty()) {
             return new FileHandle(editorConfigVO.lastOpenedSystemPath);
         }
         return new FileHandle(defaultWorkspacePath);


### PR DESCRIPTION
isEmpty() is more elegant than length() == 0, though it's actually what it does under the hood.