### PR TITLE
Added physics option for sensor. Issue #268 

### DIFF
--- a/overlap2d/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsProperties.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsProperties.java
@@ -35,6 +35,7 @@ public class UIPhysicsProperties extends UIRemovableProperties {
     private VisCheckBox allowSleepBox;
     private VisCheckBox awakeBox;
     private VisCheckBox bulletBox;
+    private VisCheckBox sensor;
 
     public UIPhysicsProperties() {
         super("Physics Component");
@@ -67,6 +68,7 @@ public class UIPhysicsProperties extends UIRemovableProperties {
         allowSleepBox = new VisCheckBox("Allow Sleep");
         awakeBox = new VisCheckBox("Awake");
         bulletBox = new VisCheckBox("Bullet");
+        sensor = new VisCheckBox("Sensor");
 
         mainTable.add(new VisLabel("Body type:", Align.right)).padRight(5).colspan(2).fillX();
         mainTable.add(bodyTypeBox).width(100).colspan(2);
@@ -109,6 +111,11 @@ public class UIPhysicsProperties extends UIRemovableProperties {
         bottomTable.add(allowSleepBox);
         bottomTable.add(awakeBox);
         bottomTable.add(bulletBox);
+
+        bottomTable.row();
+
+        bottomTable.add(sensor);
+
         mainTable.add(bottomTable).padBottom(5).colspan(4);
         mainTable.row().padTop(5);
     }
@@ -129,6 +136,7 @@ public class UIPhysicsProperties extends UIRemovableProperties {
         allowSleepBox.addListener(new CheckBoxChangeListener(getUpdateEventName()));
         awakeBox.addListener(new CheckBoxChangeListener(getUpdateEventName()));
         bulletBox.addListener(new CheckBoxChangeListener(getUpdateEventName()));
+        sensor.addListener(new CheckBoxChangeListener(getUpdateEventName()));
     }
 
     public int getBodyType() {
@@ -192,6 +200,8 @@ public class UIPhysicsProperties extends UIRemovableProperties {
     public VisCheckBox getBulletBox() {
         return bulletBox;
     }
+
+    public VisCheckBox getSensorBox() { return sensor; }
 
     @Override
     public void onClose() {

--- a/overlap2d/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsPropertiesMediator.java
+++ b/overlap2d/src/com/uwsoft/editor/view/ui/properties/panels/UIPhysicsPropertiesMediator.java
@@ -63,6 +63,7 @@ public class UIPhysicsPropertiesMediator extends UIItemPropertiesMediator<Entity
         viewComponent.getAllowSleepBox().setChecked(physicsComponent.allowSleep);
         viewComponent.getAwakeBox().setChecked(physicsComponent.awake);
         viewComponent.getBulletBox().setChecked(physicsComponent.bullet);
+        viewComponent.getSensorBox().setChecked(physicsComponent.sensor);
     }
 
     @Override
@@ -83,6 +84,7 @@ public class UIPhysicsPropertiesMediator extends UIItemPropertiesMediator<Entity
         physicsComponent.allowSleep = viewComponent.getAllowSleepBox().isChecked();
         physicsComponent.awake = viewComponent.getAwakeBox().isChecked();
         physicsComponent.bullet = viewComponent.getBulletBox().isChecked();
+        physicsComponent.sensor = viewComponent.getSensorBox().isChecked();
 
     }
 }


### PR DESCRIPTION
Added new check box in physic component, Sensor, for setting fixtureDef parameter isSensor. 

<img width="279" alt="screen shot 2015-11-12 at 9 04 40 pm" src="https://cloud.githubusercontent.com/assets/3685914/11128567/330b14fa-8983-11e5-9398-953f66a14ba5.png">

The only problem i couldn't solve is how to align the second row with first row.

And i made some changes in overlap2d-runtime so i need to make another pull request in that repo or somehow add left over code to this one?