### PR TITLE
Small fixes for win and OS X

### DIFF
--- a/overlap2d/src/com/uwsoft/editor/proxy/ProjectManager.java
+++ b/overlap2d/src/com/uwsoft/editor/proxy/ProjectManager.java
@@ -41,6 +41,7 @@ import com.vo.ProjectVO;
 import com.vo.SceneConfigVO;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
 
@@ -653,7 +654,9 @@ public class ProjectManager extends BaseProxy {
      */
     private int copyImageFilesIntoProject(Array<FileHandle> files, ResolutionEntryVO resolution, Boolean performResize) {
         float ratio = ResolutionManager.getResolutionRatio(resolution, currentProjectInfoVO.originalResolution);
-        String targetPath = currentProjectPath + "/assets/" + resolution.name + "/images";
+
+        String separator = SystemUtils.IS_OS_WINDOWS ? "\\" : "/";
+        String targetPath = currentProjectPath + separator + "assets" + separator + resolution.name + separator + "images";
         float perCopyPercent = 95.0f / files.size;
 
         int resizeWarningsCount = 0;

--- a/overlap2d/src/com/uwsoft/editor/view/stage/SandboxMediator.java
+++ b/overlap2d/src/com/uwsoft/editor/view/stage/SandboxMediator.java
@@ -477,7 +477,8 @@ public class SandboxMediator extends SimpleMediator<Sandbox> {
         private boolean isControlPressed() {
             return Gdx.input.isKeyPressed(Input.Keys.SYM)
                     || Gdx.input.isKeyPressed(Input.Keys.CONTROL_LEFT)
-                    || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT);
+                    || Gdx.input.isKeyPressed(Input.Keys.CONTROL_RIGHT)
+                    || Gdx.input.isKeyPressed(Input.Keys.SYM);
         }
 
         private boolean isShiftKey(int keycode) {


### PR DESCRIPTION
improvement: windows style separator
Issue #339: OS X change Z index shortcut not working 